### PR TITLE
Point Github icon to repo

### DIFF
--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -57,7 +57,7 @@ function Header() {
       </div>
       <div className="relative flex basis-0 justify-end gap-6 sm:gap-8 md:flex-grow">
         <ThemeSelector className="relative z-10" />
-        <Link href="https://github.com" className="group" aria-label="GitHub">
+        <Link href="https://github.com/chiefpansancolt/simplecov-tailwindcss" className="group" aria-label="GitHub">
           <GitHubIcon className="h-6 w-6 fill-slate-400 group-hover:fill-slate-500 dark:group-hover:fill-slate-300" />
         </Link>
       </div>


### PR DESCRIPTION
After reading through the docs, I clicked the Github icon to jump to the repo, but it goes to Github homepage instead. Wondered if that might be an oversight, so thought I'd create a PR. If intentional, apologies for the noise!